### PR TITLE
[BugFix | S8.C2] change BlocBuilder to BlocConsumer for better state handling in CalendarScaffold

### DIFF
--- a/lib/features/calendar/presentation/screens/calendar_screen.dart
+++ b/lib/features/calendar/presentation/screens/calendar_screen.dart
@@ -54,7 +54,15 @@ class _CalendarScaffold extends StatelessWidget {
           )
         ],
       ),
-      body: BlocBuilder<CalendarBloc, CalendarState>(
+      body: BlocConsumer<CalendarBloc, CalendarState>(
+        listenWhen: (previous, current) =>
+            previous.status != current.status ||
+            previous.statusDeleteEvent != current.statusDeleteEvent,
+        listener: (context, state) {
+          if (state.status == FormzSubmissionStatus.failure) {
+            snackbarCustom(AppConstant.ERROR_OCCURRED).show(context);
+          }
+        },
         builder: (context, state) {
           if (state.status == FormzSubmissionStatus.failure) {
             return Center(child: Text('Error'));


### PR DESCRIPTION
This pull request makes a small but significant change to the `CalendarScreen` widget to enhance state management and user feedback. The `BlocBuilder` has been replaced with a `BlocConsumer` to add a listener for handling specific state changes.

Key change:

* [`lib/features/calendar/presentation/screens/calendar_screen.dart`](diffhunk://#diff-6a5c748038b816d2f99ba32c3e6433716ff02495d7aab3f5d07f53c4cfb362d7L57-R65): Replaced `BlocBuilder` with `BlocConsumer` to enable listening for changes in `status` and `statusDeleteEvent`. Added a listener to display a custom snackbar when a failure occurs (`FormzSubmissionStatus.failure`).